### PR TITLE
Fix download of chocolatey install.ps1 in machine-level-setup

### DIFF
--- a/.git-authors
+++ b/.git-authors
@@ -1,6 +1,8 @@
 pairs:
   gg: George Gelashvili
   gh: Grant Hutchins
+  rw: Ryan Wittrup
 email_addresses:
   gg: ggelashvili@pivotal.io
   gh: ghutchins@pivotal.io
+  rw: ryan_wittrup@dell.com

--- a/.git-authors
+++ b/.git-authors
@@ -1,0 +1,6 @@
+pairs:
+  gg: George Gelashvili
+  gh: Grant Hutchins
+email_addresses:
+  gg: ggelashvili@pivotal.io
+  gh: ghutchins@pivotal.io

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # windowsmachinesetup
+
+## set proxy variables as needed
+
+If you need to have a proxy set to connect/download content from the World Wide Web, you should:
+
+```powershell
+set -name
+
+
+```
+
+## Enable running script
+Set-ExecutionPolicy Unrestricted -Scope Process

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 # windowsmachinesetup
 
-## set proxy variables as needed
-
-If you need to have a proxy set to connect/download content from the World Wide Web, you should:
-
+## Enable running script
 ```powershell
-set -name
-
-
+Set-ExecutionPolicy Unrestricted -Scope Process
 ```
 
-## Enable running script
-Set-ExecutionPolicy Unrestricted -Scope Process
+## Install
+From an unelevated prompt, run
+```powershell
+./setup.ps1
+```

--- a/machine_level_setup.ps1
+++ b/machine_level_setup.ps1
@@ -23,7 +23,6 @@ if (-not ([security.principal.windowsprincipal] [security.principal.windowsident
 {
     write-warning "This script should be run as an administrator."
     KeypressToExit $EXITCODE_NOTADMIN
-    exit
 }
 
 try
@@ -61,7 +60,7 @@ try
     if ($script_thumbprint -ne $CHOCOLATEY_THUMBPRINT) {
         Write-Warning 'FAILURE. Thumbprint of script does not match Chocolatey thumbprint.
     Please check at https://chocolatey.org/security#chocolatey-binaries-and-the-chocolatey-package'
-        exit
+        exit $EXITCODE_EXCEPTION
     }
 
     iex $script

--- a/machine_level_setup.ps1
+++ b/machine_level_setup.ps1
@@ -43,16 +43,17 @@ pushd $setup_files_dir_name
 # chain install some package managers #
 #######################################
 
-install-module -name nuget
-nuget install chocolatey
-pushd chocolatey*
-pushd tools
-    ./chocolateyInstall.ps1
-popd
-popd
+# install-module -force -name nuget
+# Install-Package NuGet.InstallCommandLineExtension
 
-. $profile
+# Install-Package chocolatey
+# Initialize-Chocolatey
+# Uninstall-Package chocolatey
 
+$thing = (New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')
+
+if (Get-Authovalid)
+iex $thing
 
 #######################
 # chocolatey packages #

--- a/machine_level_setup.ps1
+++ b/machine_level_setup.ps1
@@ -1,15 +1,18 @@
 param([Boolean]$silent=$false)
 
 $start_dir = $pwd
+$CHOCOLATEY_THUMBPRINT = "4BF7DCBC06F6D0BDFA8A0A78DE0EFB62563C4D87"
+$EXITCODE_NOTADMIN = 1
+$EXITCODE_EXCEPTION = 2
 
-function KeypressToContinue() {
+function KeypressToExit($code = 0) {
     If ($silent) {
         break;
     }
-    Write-Host -NoNewLine 'Press any key to continue...';
+    Write-Host -NoNewLine 'Press any key to exit...';
     $null = $Host.UI.RawUI.ReadKey('NoEcho,IncludeKeyDown');
+    exit $code
 }
-
 
 #######################
 # wait for user input #
@@ -18,95 +21,92 @@ function KeypressToContinue() {
 if (-not ([security.principal.windowsprincipal] [security.principal.windowsidentity]::getcurrent()).isinrole(
     [security.principal.windowsbuiltinrole] "administrator"))
 {
-    write-warning "Re-run this script as an administrator."
-    KeypressToContinue
-    break
+    write-warning "This script should be run as an administrator."
+    KeypressToExit $EXITCODE_NOTADMIN
+    exit
 }
 
-Set-ExecutionPolicy Unrestricted                 # Set policy for machine scope
-Set-ExecutionPolicy Unrestricted -Scope Process  # Ensures policy setting for this script
+try
+    {
+    Set-ExecutionPolicy Unrestricted                 # Set policy for machine scope
+    Set-ExecutionPolicy Unrestricted -Scope Process  # Ensures policy setting for this script
+
+    ##############################
+    # create install temp folder #
+    ##############################
+
+    $setup_files_dir_name = "windows-machine-setup-files"
+
+    cd $env:UserProfile/Downloads/
+    (Remove-Item -Recurse -Force $setup_files_dir_name) 2> $null
+    mkdir $setup_files_dir_name
+    pushd $setup_files_dir_name
 
 
-##############################
-# create install temp folder #
-##############################
 
-$setup_files_dir_name = "windows-machine-setup-files"
+    ##########################################
+    # install the chocolatey package manager #
+    ##########################################
 
-cd $env:UserProfile/Downloads/
-(Remove-Item -Recurse -Force $setup_files_dir_name) 2> $null
-mkdir $setup_files_dir_name
-pushd $setup_files_dir_name
+    # use system proxy and download chocolatey isntall script
+    [System.Net.WebRequest]::DefaultWebProxy.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+    $script = (New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')
 
-
-#######################################
-# chain install some package managers #
-#######################################
-
-# install-module -force -name nuget
-# Install-Package NuGet.InstallCommandLineExtension
-
-# Install-Package chocolatey
-# Initialize-Chocolatey
-# Uninstall-Package chocolatey
-
-$thing = (New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1')
-
-if (Get-Authovalid)
-iex $thing
-
-#######################
-# chocolatey packages #
-#######################
-
-choco install -y git
-choco install -y notepadplusplus
-choco install -y 7zip
-choco install -y gow
-choco install -y visualstudiocode
-choco install -y vscode-csharp vscode-gitlens
-choco install -y dotnetcore-sdk
-choco install -y openssh
+    # validate contents of chocolatey install script
+    $encoding = [system.Text.Encoding]::UTF8
+    $script_data = $encoding.GetBytes($script)
+    $script_thumbprint = (Get-AuthenticodeSignature -SourcePathOrExtension .ps1 -Content $script_data).SignerCertificate.Thumbprint
 
 
-##################
-# other packages #
-##################
+    if ($script_thumbprint -ne $CHOCOLATEY_THUMBPRINT) {
+        Write-Warning 'FAILURE. Thumbprint of script does not match Chocolatey thumbprint.
+    Please check at https://chocolatey.org/security#chocolatey-binaries-and-the-chocolatey-package'
+        exit
+    }
 
-Set-PSRepository -Name PSGallery -InstallationPolicy Trusted  # Needed to avoid prompts.
-PowerShellGet\Install-Module posh-git -Scope AllUsers
+    iex $script
 
+    #######################
+    # chocolatey packages #
+    #######################
 
-###############
-# other setup #
-###############
+    choco install -y git
+    choco install -y notepadplusplus
+    choco install -y 7zip
+    choco install -y gow
+    choco install -y visualstudiocode
+    choco install -y vscode-csharp vscode-gitlens
+    choco install -y dotnetcore-sdk
+    choco install -y openssh
+    choco install -y atom
 
-cd ~/downloads
-(new-object system.net.webclient).downloadfile('https://github.com/git-duet/git-duet/releases/download/0.5.2/windows_amd64.tar.gz', "$env:homepath\\downloads\\git-duet-amd64.tar.gz")
-set-alias 7z "$env:programfiles\7-zip\7z.exe"
-# extract and say yes to prompts
-7z x -y git-duet-amd64.tar.gz git-duet-amd64.tar
-7z x -y git-duet-amd64.tar -o"$env:programfiles\git\cmd"
+    ##################
+    # other packages #
+    ##################
 
+    Install-PackageProvider -Name NuGet -Force
+    Set-PSRepository -Name PSGallery -InstallationPolicy Trusted  # Needed to avoid prompts.
+    PowerShellGet\Install-Module posh-git -Scope AllUsers
 
-###############
-# git aliases #
-###############
+    ###############
+    # other setup #
+    ###############
 
-set-alias git "$env:ProgramFiles\Git\cmd\git.exe"
-
-git config --global alias.co checkout
-git config --global alias.br branch
-git config --global alias.st status
-git config --global alias.ci duet-commit
-git config --global alias.lola "log --graph --decorate --pretty=oneline --abbrev-commit --all"
-git config --global alias.lol "log --graph --decorate --pretty=oneline --abbrev-commit"
-
-cd $start_dir
-
-
-#######################
-# wait for user input #
-#######################
-
-KeypressToContinue
+    cd ~/downloads
+    (new-object system.net.webclient).downloadfile('https://github.com/git-duet/git-duet/releases/download/0.5.2/windows_amd64.tar.gz', "$env:homepath\\downloads\\git-duet-amd64.tar.gz")
+    set-alias 7z "$env:programfiles\7-zip\7z.exe"
+    # extract and say yes to prompts
+    7z x -y git-duet-amd64.tar.gz git-duet-amd64.tar
+    7z x -y git-duet-amd64.tar -o"$env:programfiles\git\cmd"
+}
+catch {
+    Write-Warning "attention-grabbing whitespace below"
+    Write-Warning ""
+    Write-Warning ""
+    Write-Warning ""
+    Write-Warning ""
+    Write-Warning ""
+    Write-Warning ""
+    Write-Warning "Something broke :( See output above"
+    KeypressToExit $EXITCODE_EXCEPTION
+}

--- a/setup.ps1
+++ b/setup.ps1
@@ -4,13 +4,17 @@ param([Boolean]$silent=$false)
 $start_path = $pwd.path
 
 Write-Host " * Running machine-level setup..."
+
 $process = Start-Process powershell -Wait -PassThru -Verb runas -ArgumentList "-File $start_path/machine_level_setup.ps1"
 
 Write-Host $process.ExitCode
 If ($process.ExitCode -ne 0) {
-    Write-Warning 'Situation is suboptimal. Machine-level setup failed with error code: $($process.ExitCode)'
+    Write-Warning "Situation is suboptimal. Machine-level setup failed with error code: $($process.ExitCode)"
     break
 }
 
+Write-Host " * Making machine-level PATH changes apply"
+
 Write-Host " * Running user-level setup..."
+Unblock-File user_level_setup.ps1
 ./user_level_setup.ps1

--- a/user_level_setup.ps1
+++ b/user_level_setup.ps1
@@ -1,1 +1,18 @@
+# need to re-source PATH since we're in an old terminal context 
+# (that hasn't been updated after chocolatey installs)
+& "$env:ProgramData\chocolatey\bin\refreshenv.CMD"
+
+set-alias git "$env:ProgramFiles\Git\cmd\git.exe"
+
 Add-PoshGitToProfile
+
+###############
+# git aliases #
+###############
+
+git config --global alias.co checkout
+git config --global alias.br branch
+git config --global alias.st status
+git config --global alias.ci duet-commit
+git config --global alias.lola "log --graph --decorate --pretty=oneline --abbrev-commit --all"
+git config --global alias.lol "log --graph --decorate --pretty=oneline --abbrev-commit"


### PR DESCRIPTION
When behind a proxy that pulls settings/credentials from Windows network settings, the chocolatey install script can't be simply downloaded.

Using a one-liner fix as documented on https://chocolatey.org/install#installing-behind-a-proxy