### PR TITLE
Use 'CurrentUser' as scope in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Enable running script
 ```powershell
-Set-ExecutionPolicy Unrestricted -Scope Process
+Set-ExecutionPolicy Unrestricted -Scope CurrentUser
 ```
 
 ## Install


### PR DESCRIPTION
The machine_level_setup.ps1 script won't work in a separate process if the execution policy is only set to Unrestricted for the non-elevated PowerShell process.
